### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,13 @@
         "symfony/filesystem": "~2.3 || ~3.1",
         "symfony/class-loader": "~2.2 || ~3.1",
         "backup-manager/backup-manager": "^1.0",
-        "league/flysystem-aws-s3-v2": "^1.0",
         "league/flysystem-dropbox": "^1.0",
         "league/flysystem-rackspace": "^1.0",
         "league/flysystem-sftp": "^1.0"
+    },
+    "suggest": {
+        "league/flysystem-aws-s3-v2": "to use AWS S3, version 2 (compatible with other vendors like Google Cloud Storage or ExoScale)",
+        "league/flysystem-aws-s3-v3": "to use AWS S3, version 3 (compatible with newer aws-regions like Frankfurt/Europe)"
     },
     "autoload": {
         "psr-4": { "BM\\BackupManagerBundle\\": "" }


### PR DESCRIPTION
removed require for `league/flysystem-aws-s3-v2`, which is a problem, when you are already using `league/flysystem-aws-s3-v3` - instead suggesting both.