### PR TITLE
Add the missing "symfony/http-kernel" dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": ">=5.5",
         "symfony/dependency-injection": "~2.3 || ~3.1",
+        "symfony/http-kernel": "~2.6 || ~3.0 || ^4.0",
         "symfony/config": "~2.3 || ~3.1",
         "symfony/filesystem": "~2.3 || ~3.1",
         "symfony/class-loader": "~2.2 || ~3.1",


### PR DESCRIPTION
Although the driver uses Symfony\Component\HttpKernel\* , this is not mentioned in composer.json. Many Symfony projects have this dependency already - but for a new project, following the installation steps (`composer backup-manager/symfony "^1.0"`) is insufficient: you would end up with a Symfony driver that's missing a dependency. Explicitly adding it into composer.json fixes the issue.