### PR TITLE
Make sure we can have multiple storage names with the same type

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,60 +18,45 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->arrayNode('storage')->useAttributeAsKey('name')
-                    ->prototype('array')
+                ->variableNode('storage')
                     ->validate()
                         ->always()
-                        ->then(function ($config) {
-                            switch ($config['type']) {
-                                case 'Local':
-                                    $this->validateAuthenticationType(['root'], $config, 'Local');
-                                    break;
-                                case 'AwsS3':
-                                    $this->validateAuthenticationType(['key', 'secret', 'region', 'version', 'bucket', 'root'], $config, 'AwsS3');
-                                    break;
-                                case 'Rackspace':
-                                    $this->validateAuthenticationType(['username', 'password', 'container'], $config, 'Rackspace');
-                                    break;
-                                case 'Dropbox':
-                                    $this->validateAuthenticationType(['token', 'key', 'secret', 'app', 'root'], $config, 'Dropbox');
-                                    break;
-                                case 'Ftp':
-                                    $this->validateAuthenticationType(['host', 'username', 'password', 'root', 'port', 'passive', 'ssl', 'timeout'], $config, 'Ftp');
-                                    break;
-                                case 'Sftp':
-                                    $this->validateAuthenticationType(['host', 'username', 'password', 'root', 'port', 'timeout', 'privateKey'], $config, 'Sftp');
-                                    break;
+                        ->then(function ($storageConfig) {
+                            foreach ($storageConfig as $name => $config) {
+                                if (!isset($config['type'])) {
+                                    throw new InvalidConfigurationException(sprintf('You must define a "type" for storage "%s"', $name));
+                                }
+                                $validTypes = ['Local', 'AwsS3', 'Rackspace', 'Dropbox', 'Ftp', 'Sftp'];
+                                if (!in_array($config['type'], $validTypes)) {
+                                    throw new InvalidConfigurationException(sprintf('Type must be one of "%s", got "%s"', implode(', ', $validTypes), $config['type']));
+                                }
+
+                                switch ($config['type']) {
+                                    case 'Local':
+                                        $this->validateAuthenticationType(['root'], $config, 'Local');
+                                        break;
+                                    case 'AwsS3':
+                                        $this->validateAuthenticationType(['key', 'secret', 'region', 'version', 'bucket', 'root'], $config, 'AwsS3');
+                                        break;
+                                    case 'Rackspace':
+                                        $this->validateAuthenticationType(['username', 'password', 'container'], $config, 'Rackspace');
+                                        break;
+                                    case 'Dropbox':
+                                        $this->validateAuthenticationType(['token', 'key', 'secret', 'app', 'root'], $config, 'Dropbox');
+                                        break;
+                                    case 'Ftp':
+                                        $this->validateAuthenticationType(['host', 'username', 'password', 'root', 'port', 'passive', 'ssl', 'timeout'], $config, 'Ftp');
+                                        break;
+                                    case 'Sftp':
+                                        $this->validateAuthenticationType(['host', 'username', 'password', 'root', 'port', 'timeout', 'privateKey'], $config, 'Sftp');
+                                        break;
+                                }
                             }
-                            return $config;
+
+                            return $storageConfig;
                         })
                     ->end()
-                    ->children()
-                        ->enumNode('type')
-                            ->values(['Local', 'AwsS3', 'Rackspace', 'Dropbox', 'Ftp', 'Sftp'])
-                            ->isRequired()
-                            ->cannotBeEmpty()
-                        ->end()
-                        ->scalarNode('root')->end()
-                        ->scalarNode('key')->end()
-                        ->scalarNode('secret')->end()
-                        ->scalarNode('region')->end()
-                        ->scalarNode('version')->end()
-                        ->scalarNode('bucket')->end()
-                        ->scalarNode('root')->end()
-                        ->scalarNode('username')->end()
-                        ->scalarNode('password')->end()
-                        ->scalarNode('container')->end()
-                        ->scalarNode('token')->end()
-                        ->scalarNode('app')->end()
-                        ->scalarNode('host')->end()
-                        ->scalarNode('port')->end()
-                        ->scalarNode('passive')->end()
-                        ->scalarNode('ssl')->end()
-                        ->scalarNode('timeout')->end()
-                        ->scalarNode('privateKey')->end()
-                        ->end()
-                    ->end()
+
                 ->end() // End storage
 
                 ->arrayNode('database')->isRequired()
@@ -97,22 +82,22 @@ class Configuration implements ConfigurationInterface
      *
      * @param array  $expected Fields that must exist
      * @param array  $actual   Actual configuration hashmap
-     * @param string $authName Name of authentication method for error messages
+     * @param string $typeName Name of storage type for error messages
      *
      * @throws InvalidConfigurationException If $actual does not have exactly the keys specified in $expected (plus 'type')
      */
-    private function validateAuthenticationType(array $expected, array $actual, $authName)
+    private function validateAuthenticationType(array $expected, array $actual, $typeName)
     {
         unset($actual['type']);
         $actual = array_keys($actual);
-        sort($actual);
-        sort($expected);
-        if ($expected === $actual) {
+
+        if (empty(array_diff($actual, $expected))) {
             return;
         }
+
         throw new InvalidConfigurationException(sprintf(
-            'Storage type "%s" requires keys "%s" but got "%s"',
-            $authName,
+            'Storage type "%s" has valid keys "%s" but got "%s"',
+            $typeName,
             implode(', ', $expected),
             implode(', ', $actual)
         ));

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -4,6 +4,7 @@ namespace BM\BackupManagerBundle\DependencyInjection;
 
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 
 class Configuration implements ConfigurationInterface
 {
@@ -17,70 +18,62 @@ class Configuration implements ConfigurationInterface
 
         $rootNode
             ->children()
-                ->arrayNode('storage')->isRequired()
+                ->arrayNode('storage')->useAttributeAsKey('name')
+                    ->prototype('array')
+                    ->validate()
+                        ->always()
+                        ->then(function ($config) {
+                            switch ($config['type']) {
+                                case 'Local':
+                                    $this->validateAuthenticationType(['root'], $config, 'Local');
+                                    break;
+                                case 'AwsS3':
+                                    $this->validateAuthenticationType(['key', 'secret', 'region', 'version', 'bucket', 'root'], $config, 'AwsS3');
+                                    break;
+                                case 'Rackspace':
+                                    $this->validateAuthenticationType(['username', 'password', 'container'], $config, 'Rackspace');
+                                    break;
+                                case 'Dropbox':
+                                    $this->validateAuthenticationType(['token', 'key', 'secret', 'app', 'root'], $config, 'Dropbox');
+                                    break;
+                                case 'Ftp':
+                                    $this->validateAuthenticationType(['host', 'username', 'password', 'root', 'port', 'passive', 'ssl', 'timeout'], $config, 'Ftp');
+                                    break;
+                                case 'Sftp':
+                                    $this->validateAuthenticationType(['host', 'username', 'password', 'root', 'port', 'timeout', 'privateKey'], $config, 'Sftp');
+                                    break;
+                            }
+                            return $config;
+                        })
+                    ->end()
                     ->children()
-                        ->arrayNode('local')
-                            ->children()
-                                ->scalarNode('type')->end()
-                                ->scalarNode('root')->end()
-                            ->end()
+                        ->enumNode('type')
+                            ->values(['Local', 'AwsS3', 'Rackspace', 'Dropbox', 'Ftp', 'Sftp'])
+                            ->isRequired()
+                            ->cannotBeEmpty()
                         ->end()
-                        ->arrayNode('s3')
-                            ->children()
-                                ->scalarNode('type')->end()
-                                ->scalarNode('key')->end()
-                                ->scalarNode('secret')->end()
-                                ->scalarNode('region')->end()
-                                ->scalarNode('version')->end()
-                                ->scalarNode('bucket')->end()
-                                ->scalarNode('root')->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('rackspace')
-                            ->children()
-                                ->scalarNode('type')->end()
-                                ->scalarNode('username')->end()
-                                ->scalarNode('password')->end()
-                                ->scalarNode('container')->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('dropbox')
-                            ->children()
-                                ->scalarNode('type')->end()
-                                ->scalarNode('token')->end()
-                                ->scalarNode('key')->end()
-                                ->scalarNode('secret')->end()
-                                ->scalarNode('app')->end()
-                                ->scalarNode('root')->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('ftp')
-                            ->children()
-                                ->scalarNode('type')->end()
-                                ->scalarNode('host')->end()
-                                ->scalarNode('username')->end()
-                                ->scalarNode('password')->end()
-                                ->scalarNode('root')->end()
-                                ->scalarNode('port')->end()
-                                ->scalarNode('passive')->end()
-                                ->scalarNode('ssl')->end()
-                                ->scalarNode('timeout')->end()
-                            ->end()
-                        ->end()
-                        ->arrayNode('sftp')
-                            ->children()
-                                ->scalarNode('type')->end()
-                                ->scalarNode('host')->end()
-                                ->scalarNode('username')->end()
-                                ->scalarNode('password')->end()
-                                ->scalarNode('root')->end()
-                                ->scalarNode('port')->end()
-                                ->scalarNode('timeout')->end()
-                                ->scalarNode('privateKey')->end()
-                            ->end()
+                        ->scalarNode('root')->end()
+                        ->scalarNode('key')->end()
+                        ->scalarNode('secret')->end()
+                        ->scalarNode('region')->end()
+                        ->scalarNode('version')->end()
+                        ->scalarNode('bucket')->end()
+                        ->scalarNode('root')->end()
+                        ->scalarNode('username')->end()
+                        ->scalarNode('password')->end()
+                        ->scalarNode('container')->end()
+                        ->scalarNode('token')->end()
+                        ->scalarNode('app')->end()
+                        ->scalarNode('host')->end()
+                        ->scalarNode('port')->end()
+                        ->scalarNode('passive')->end()
+                        ->scalarNode('ssl')->end()
+                        ->scalarNode('timeout')->end()
+                        ->scalarNode('privateKey')->end()
                         ->end()
                     ->end()
-                ->end()
+                ->end() // End storage
+
                 ->arrayNode('database')->isRequired()
                     ->prototype('array')
                         ->children()
@@ -97,5 +90,31 @@ class Configuration implements ConfigurationInterface
         ;
 
         return $treeBuilder;
+    }
+
+    /**
+     * Validate that the configuration fragment has the specified keys and none other.
+     *
+     * @param array  $expected Fields that must exist
+     * @param array  $actual   Actual configuration hashmap
+     * @param string $authName Name of authentication method for error messages
+     *
+     * @throws InvalidConfigurationException If $actual does not have exactly the keys specified in $expected (plus 'type')
+     */
+    private function validateAuthenticationType(array $expected, array $actual, $authName)
+    {
+        unset($actual['type']);
+        $actual = array_keys($actual);
+        sort($actual);
+        sort($expected);
+        if ($expected === $actual) {
+            return;
+        }
+        throw new InvalidConfigurationException(sprintf(
+            'Storage type "%s" requires keys "%s" but got "%s"',
+            $authName,
+            implode(', ', $expected),
+            implode(', ', $actual)
+        ));
     }
 }

--- a/Tests/Unit/DependencyInjection/BMBackupManagerExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/BMBackupManagerExtensionTest.php
@@ -20,22 +20,33 @@ class BMBackupManagerExtensionTest extends AbstractExtensionTestCase
         );
     }
 
-    /**
-     * @test
-     */
     public function testReplacementOfConfig()
     {
-        $storageConfig = ['local'=>['type'=>'local']];
+        $storageConfig = ['local'=>['type'=>'Local', 'root'=>'/foo']];
         $dbConfig = ['dev'=>['type'=>'mysql']];
 
-        $this->load(
-            [
-                'storage' => $storageConfig,
-                'database' => $dbConfig,
-            ]
-        );
+        $this->load([
+            'storage' => $storageConfig,
+            'database' => $dbConfig,
+        ]);
 
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('backup_manager.config_storage', 0, $storageConfig);
         $this->assertContainerBuilderHasServiceDefinitionWithArgument('backup_manager.config_database', 0, $dbConfig);
+    }
+
+    /**
+     * Make sure we can have multiple storage names with the same type
+     */
+    public function testCustomConfigNames()
+    {
+        $storageConfig = ['foobar'=>['type'=>'Ftp', 'host' => 'foo', 'port' => 21, 'passive'=>true, 'password' =>'xx', 'root'=>'ss', 'ssl'=>true, 'timeout'=>10, 'username'=>'x']];
+        $dbConfig = ['dev'=>['type'=>'mysql']];
+
+        $this->load([
+            'storage' => $storageConfig,
+            'database' => $dbConfig,
+        ]);
+
+        $this->assertContainerBuilderHasServiceDefinitionWithArgument('backup_manager.config_storage', 0, $storageConfig);
     }
 }

--- a/Tests/Unit/DependencyInjection/BMBackupManagerExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/BMBackupManagerExtensionTest.php
@@ -22,7 +22,7 @@ class BMBackupManagerExtensionTest extends AbstractExtensionTestCase
 
     public function testReplacementOfConfig()
     {
-        $storageConfig = ['local'=>['type'=>'Local', 'root'=>'/foo']];
+        $storageConfig = ['local'=>['type'=>'local', 'root'=>'/foo']];
         $dbConfig = ['dev'=>['type'=>'mysql']];
 
         $this->load([

--- a/Tests/Unit/DependencyInjection/BMBackupManagerExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/BMBackupManagerExtensionTest.php
@@ -39,7 +39,7 @@ class BMBackupManagerExtensionTest extends AbstractExtensionTestCase
      */
     public function testCustomConfigNames()
     {
-        $storageConfig = ['foobar'=>['type'=>'Ftp', 'host' => 'foo', 'port' => 21, 'passive'=>true, 'password' =>'xx', 'root'=>'ss', 'ssl'=>true, 'timeout'=>10, 'username'=>'x']];
+        $storageConfig = ['foobar'=>['type'=>'Ftp', 'host' => 'foo', 'password' =>'xx', 'username'=>'x']];
         $dbConfig = ['dev'=>['type'=>'mysql']];
 
         $this->load([


### PR DESCRIPTION
This PR is not perfect yet. We cannot add parameters to a storage type without it being a BC break. 

We should add the notion of "optional parameters. "