### PR TITLE
update version number

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^5.5 || ^7.0",
-        "backup-manager/backup-manager": "^1.3",
+        "backup-manager/backup-manager": "^1.2",
         "nyholm/dsn": "^0.1",
         "symfony/config": "^2.7 || ^3.1 || ^4.0",
         "symfony/console": "^2.7 || ^3.1 || ^4.0",


### PR DESCRIPTION
fix require bug.

```
composer require backup-manager/symfony
Using version ^2.2 for backup-manager/symfony
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for backup-manager/symfony ^2.2 -> satisfiable by backup-manager/symfony[2.2.0].
    - backup-manager/symfony 2.2.0 requires backup-manager/backup-manager ^1.3 -> no matching package found.

Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
 - It's a private package and you forgot to add a custom repository to find it

```