### PR TITLE
Upgraded backup-manager dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,25 +23,26 @@ matrix:
     fast_finish: true
     include:
           # Minimum supported Symfony version and latest PHP version
-        - php: 7.2
+        - php: 7.3
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
         - php: 7.4
           env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" SYMFONY_DEPRECATIONS_HELPER="weak"
 
           # Test the latest stable release
-        - php: 7.2
         - php: 7.3
         - php: 7.4
           env: COVERAGE=true TEST_COMMAND="composer test-ci"
 
           # Test LTS versions
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^3"
-        - php: 7.2
+        - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
+        - php: 7.3
+          env: DEPENDENCIES="dunglas/symfony-lock:^5"
 
           # Latest commit to master
-        - php: 7.2
+        - php: 7.3
           env: STABILITY="dev"
 
     allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ matrix:
           env: DEPENDENCIES="dunglas/symfony-lock:^3"
         - php: 7.3
           env: DEPENDENCIES="dunglas/symfony-lock:^4"
-        - php: 7.3
-          env: DEPENDENCIES="dunglas/symfony-lock:^5"
 
           # Latest commit to master
         - php: 7.3

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ php bin/console backup-manager:restore development s3 test/backup.sql.gz -c gzip
 Requirements
 ============
 
-- PHP 7.2
+- PHP 7.3
 - MySQL support requires `mysqldump` and `mysql` command-line binaries
 - PostgreSQL support requires `pg_dump` and `psql` command-line binaries
 - Gzip support requires `gzip` and `gunzip` command-line binaries

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "backup-manager/backup-manager": "^1.3",
+        "backup-manager/backup-manager": "^3.0",
         "nyholm/dsn": "^1.0",
         "symfony/config": "^3.4 || ^4.4 || ^5.0",
         "symfony/console": "^3.4 || ^4.4 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.3",
         "backup-manager/backup-manager": "^3.0",
         "nyholm/dsn": "^1.0",
         "symfony/config": "^3.4 || ^4.4 || ^5.0",


### PR DESCRIPTION
I saw a lot of people mentioned that the dependency needs to be updated for Symfony 5. But nobody create a pull request. So here it is.

fixes #65 