### PR TITLE
Add option 'extraParams' for database's config

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 3.2.1
+## UNRELEASED
 
 ### Added
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 3.2.1
+
+### Added
+
+- Add option 'extraParams' for database's config
+
 ## 3.2.0
 
 ### Added

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -115,6 +115,7 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('dsn')->end()
                             ->booleanNode('singleTransaction')->end()
                             ->booleanNode('ssl')->end()
+                            ->scalarNode('extraParams')->end()
                             ->arrayNode('ignoreTables')
                                  ->prototype('scalar')->end()
                             ->end()


### PR DESCRIPTION
Hello,

On https://github.com/backup-manager/backup-manager, you have an extraParams for database config, but on symfony's repo we can not use this 'extraParams'