### PR TITLE
Add PHP 8.0 support to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.3 || ^8.0",
         "backup-manager/backup-manager": "^3.0",
         "nyholm/dsn": "^2.0",
         "symfony/config": "^3.4 || ^4.4 || ^5.0",


### PR DESCRIPTION
Nothing tricky here - just changing the version constraint to permit installing in PHP 8.0 projects.